### PR TITLE
Create group fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "ace-css": "^1.1.0",
     "elm-format": "^0.8.1",
+    "elm-test": "0.18.12",
     "font-awesome": "^4.7.0",
     "http-server": "^0.11.1",
     "json-server": "^0.14.0",

--- a/src/Models/Group.elm
+++ b/src/Models/Group.elm
@@ -1,13 +1,13 @@
-module Models.Group exposing (FormType, Group, init)
+module Models.Group exposing (FormType(..), Group, formTypeToString, init, stringToFormType)
 
 import Models.Product exposing (Product)
 
 
 type alias Group =
-    { id : Int
+    { id : Maybe Int
     , name : String
     , disclosure : String
-    , form_type : String
+    , form_type : FormType
     , employee_contribution : String
     , payment_mode : Int
     , products : List Product
@@ -16,10 +16,10 @@ type alias Group =
 
 init : Group
 init =
-    { id = 0
+    { id = Nothing
     , name = ""
     , disclosure = ""
-    , form_type = ""
+    , form_type = Life
     , employee_contribution = ""
     , payment_mode = 0
     , products = []
@@ -30,3 +30,32 @@ type FormType
     = Life
     | Ibew
     | HealthSuppOnlyProduct
+
+
+stringToFormType : String -> Result String FormType
+stringToFormType str =
+    case str of
+        "life" ->
+            Ok Life
+
+        "ibew" ->
+            Ok Ibew
+
+        "health_supp_only_product" ->
+            Ok HealthSuppOnlyProduct
+
+        _ ->
+            Err <| "Unknown formtype" ++ str
+
+
+formTypeToString : FormType -> String
+formTypeToString formType =
+    case formType of
+        Life ->
+            "life"
+
+        Ibew ->
+            "ibew"
+
+        HealthSuppOnlyProduct ->
+            "health_supp_only_product"

--- a/src/Pages/Groups.elm
+++ b/src/Pages/Groups.elm
@@ -51,7 +51,7 @@ update msg model token =
             ( model, newMsg )
 
         DeleteGroup id (Ok message) ->
-            ( { model | groups = removeModelFromList id model.groups }, Cmd.none )
+            ( { model | groups = removeModelFromNullableIdList (Just id) model.groups }, Cmd.none )
 
         DeleteGroup id (Err error) ->
             ( { model | errorMsg = toString error }, Cmd.none )
@@ -65,7 +65,7 @@ update msg model token =
             ( model, newMsg )
 
         PreviewGroup id (Ok token) ->
-            ( model, Port.openWindow (Requests.Group.previewUrl id token) )
+            ( model, Port.openWindow (Requests.Group.previewUrl (Just id) token) )
 
         PreviewGroup id (Err error) ->
             ( { model | errorMsg = toString error }, Cmd.none )

--- a/src/Pages/Helper.elm
+++ b/src/Pages/Helper.elm
@@ -1,4 +1,4 @@
-module Pages.Helper exposing (RecordWithID, removeModelFromList)
+module Pages.Helper exposing (RecordWithID, RecordWithMaybeId, removeModelFromList, removeModelFromNullableIdList)
 
 
 removeModelFromList : Int -> List (RecordWithID a) -> List (RecordWithID a)
@@ -6,5 +6,14 @@ removeModelFromList id =
     List.filter (\model -> model.id /= id)
 
 
+removeModelFromNullableIdList : Maybe Int -> List (RecordWithMaybeId a) -> List (RecordWithMaybeId a)
+removeModelFromNullableIdList id =
+    List.filter (\model -> model.id /= id)
+
+
 type alias RecordWithID a =
     { a | id : Int }
+
+
+type alias RecordWithMaybeId a =
+    { a | id : Maybe Int }

--- a/src/Requests/Group.elm
+++ b/src/Requests/Group.elm
@@ -1,12 +1,12 @@
-module Requests.Group exposing (delete, get, getAll, previewUrl, update)
+module Requests.Group exposing (create, delete, get, getAll, groupDecoder, groupEncoder, groupsDecoder, groupsUrl, previewUrl, update)
 
 -- import Date exposing (Date)
 
 import Http
-import Json.Decode as Decode
+import Json.Decode as Decode exposing (..)
 import Json.Decode.Pipeline exposing (custom, decode, optional, optionalAt, required, requiredAt)
 import Json.Encode as Encode
-import Models.Group exposing (Group)
+import Models.Group exposing (FormType(..), Group, formTypeToString, stringToFormType)
 import Requests.Base exposing (..)
 import Requests.Product
 import Task exposing (Task)
@@ -34,24 +34,38 @@ get groupId token =
         , expect = Http.expectJson (dataDecoder groupDecoder)
         , method = "GET"
         , timeout = Nothing
-        , url = groupUrl groupId
+        , url = groupUrl (Just groupId)
         , withCredentials = False
         }
         |> Http.toTask
 
 
 update : Group -> String -> Task Http.Error Group
-update group token =
-    Http.request
-        { headers = [ Http.header "Authorization" ("Bearer " ++ token) ]
-        , body = groupEncoder group
-        , expect = Http.expectJson (dataDecoder groupDecoder)
-        , method = "PATCH"
-        , timeout = Nothing
-        , url = groupUrl group.id
-        , withCredentials = False
-        }
+update =
+    createOrUpdate
+
+
+create : Group -> String -> Task Http.Error Group
+create =
+    createOrUpdate
+
+
+createOrUpdate : Group -> String -> Task Http.Error Group
+createOrUpdate group token =
+    saveConfig group token
+        |> Http.request
         |> Http.toTask
+
+
+saveConfig group token =
+    { headers = [ Http.header "Authorization" ("Bearer " ++ token) ]
+    , body = groupJsonBody group
+    , expect = Http.expectJson (dataDecoder groupDecoder)
+    , method = groupMethod group.id
+    , timeout = Nothing
+    , url = groupUrl group.id
+    , withCredentials = False
+    }
 
 
 delete : Int -> String -> Task Http.Error String
@@ -62,32 +76,44 @@ delete groupId token =
         , body = Http.emptyBody
         , method = "DELETE"
         , timeout = Nothing
-        , url = groupUrl groupId
+        , url = groupUrl (Just groupId)
         , withCredentials = False
         }
         |> Http.toTask
 
 
-previewUrl : Int -> String -> String
+previewUrl : Maybe Int -> String -> String
 previewUrl groupId fileToken =
     groupUrl groupId ++ "/preview?file_token=" ++ fileToken
 
 
-groupEncoder : Group -> Http.Body
+groupEncoder : Group -> Encode.Value
 groupEncoder group =
     let
+        idAttr =
+            case group.id of
+                Just actualId ->
+                    [ ( "id", Encode.int actualId ) ]
+
+                Nothing ->
+                    []
+
         attributes =
-            [ ( "id", Encode.int group.id )
-            , ( "name", Encode.string group.name )
-            , ( "disclosure", Encode.string group.disclosure )
-            , ( "form_type", Encode.string group.form_type )
-            , ( "employee_contribution", Encode.string group.employee_contribution )
-            , ( "payment_mode", Encode.int group.payment_mode )
-            , ( "product_pricing", Requests.Product.encode group.products )
-            ]
+            idAttr
+                ++ [ ( "name", Encode.string group.name )
+                   , ( "disclosure", Encode.string group.disclosure )
+                   , ( "form_type", (formTypeToString >> Encode.string) group.form_type )
+                   , ( "employee_contribution", Encode.string group.employee_contribution )
+                   , ( "payment_mode", Encode.int group.payment_mode )
+                   , ( "product_pricing", Requests.Product.encode group.products )
+                   ]
     in
     Encode.object attributes
-        |> Http.jsonBody
+
+
+groupJsonBody : Group -> Http.Body
+groupJsonBody =
+    groupEncoder >> Http.jsonBody
 
 
 groupsDecoder : Decode.Decoder (List Group)
@@ -98,20 +124,71 @@ groupsDecoder =
 groupDecoder : Decode.Decoder Group
 groupDecoder =
     decode Group
-        |> custom (Decode.at [ "id" ] Decode.string |> Decode.andThen stringToInt)
+        -- require groups coming from JSON to have ids defined.
+        |> required "id" (Decode.map Just flexibleInt)
         |> requiredAt [ "attributes", "name" ] Decode.string
         |> optionalAt [ "attributes", "disclosure" ] Decode.string ""
-        |> optionalAt [ "attributes", "form_type" ] Decode.string ""
+        |> optionalAt [ "attributes", "form_type" ] parseFormType Life
         |> optionalAt [ "attributes", "employee_contribution" ] Decode.string ""
         |> optionalAt [ "attributes", "payment_mode" ] Decode.int 12
         |> optionalAt [ "attributes", "product_pricing", "products" ] Requests.Product.productsDecoder []
 
 
-groupUrl : Int -> String
-groupUrl groupId =
-    groupsUrl ++ "/" ++ toString groupId
+groupMethod : Maybe Int -> String
+groupMethod maybeGroupId =
+    case maybeGroupId of
+        Just _ ->
+            "PATCH"
+
+        Nothing ->
+            "POST"
+
+
+groupUrl : Maybe Int -> String
+groupUrl maybeGroupId =
+    case maybeGroupId of
+        Just id ->
+            groupsUrl ++ "/" ++ toString id
+
+        Nothing ->
+            groupsUrl
 
 
 groupsUrl : String
 groupsUrl =
     baseUrl ++ "/groups"
+
+
+
+-- HELPERS
+
+
+{-| Extract an int using [`String.toInt`](http://package.elm-lang.org/packages/elm-lang/core/latest/String#toInt)
+import Json.Decode exposing (..)
+""" { "field": "123" } """
+|> decodeString (field "field" parseInt)
+--> Ok 123
+-}
+parseInt : Decode.Decoder Int
+parseInt =
+    Decode.string |> Decode.andThen (String.toInt >> fromResult)
+
+
+flexibleInt : Decode.Decoder Int
+flexibleInt =
+    Decode.oneOf [ parseInt, Decode.int ]
+
+
+fromResult : Result String a -> Decode.Decoder a
+fromResult result =
+    case result of
+        Ok successValue ->
+            Decode.succeed successValue
+
+        Err errorMessage ->
+            Decode.fail errorMessage
+
+
+parseFormType : Decode.Decoder FormType
+parseFormType =
+    Decode.string |> Decode.andThen (stringToFormType >> fromResult)

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -108,7 +108,7 @@ routeParser =
         [ map Routes.Home top
         , map Routes.Groups (s (routeToUrl Routes.Groups))
         , map Routes.EditGroup (s (routeToUrl Routes.Groups) </> int)
-        , map Routes.CreateGroup (s "group") -- How to make it "groups/new"
+        , map Routes.CreateGroup (s "groups" </> s "new")
         , map Routes.Batches (s (routeToUrl Routes.Batches))
         , map Routes.CreateBatch (s "batches" </> s "new" </> int)
         , map Routes.Users (s (routeToUrl Routes.Users))

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -155,4 +155,11 @@ update msg model =
 
         -- Catch All for now
         ( _, _ ) ->
+            let
+                _ =
+                    Debug.log "Fell through update. Msg" msg
+
+                _ =
+                    Debug.log "Fell through update. Page" page
+            in
             ( model, Cmd.none )

--- a/src/Views/Group.elm
+++ b/src/Views/Group.elm
@@ -21,7 +21,7 @@ view model =
                 , button
                     [ class "uk-button uk-button-primary uk-margin-small"
                     , type_ "button"
-                    , onClick Components.Group.UpdateGroupRequest
+                    , onClick Components.Group.SaveGroupRequest
                     ]
                     [ text "Save" ]
                 ]

--- a/src/Views/Groups.elm
+++ b/src/Views/Groups.elm
@@ -45,32 +45,39 @@ viewGroupList groups =
 
 viewGroup : Group -> Html Msg
 viewGroup group =
-    tr []
-        [ td []
-            [ a ([ class "uk-link-text" ] ++ onClickRoute (Routes.EditGroup group.id))
-                [ text group.name ]
-            ]
-        , td []
-            [ button
-                [ class "uk-button uk-button-default uk-button-small"
-                , type_ "button"
-                , onClick (GroupsMsg (Pages.Groups.PreviewGroupRequest group.id))
+    case group.id of
+        Nothing ->
+            tr []
+                [ td [] [ text group.name ] ]
+
+        Just groupId ->
+            tr []
+                [ td []
+                    [ a ([ class "uk-link-text" ] ++ onClickRoute (Routes.EditGroup groupId))
+                        [ text group.name ]
+                    ]
+                , td []
+                    [ button
+                        [ class "uk-button uk-button-default uk-button-small"
+                        , type_ "button"
+                        , onClick (GroupsMsg (Pages.Groups.PreviewGroupRequest groupId))
+                        ]
+                        [ text "Preview" ]
+                    ]
+                , td []
+                    [ button
+                        [ class "uk-button uk-button-default uk-button-small"
+                        , type_ "button"
+                        , onClick (SetRoute (Routes.CreateBatch groupId))
+                        ]
+                        [ text "Create Batch" ]
+                    ]
+                , td []
+                    [ button
+                        [ class "uk-button uk-button-danger uk-button-small"
+                        , type_ "button"
+                        , onClick (GroupsMsg (Pages.Groups.DeleteGroupRequest groupId))
+                        ]
+                        [ text "Delete" ]
+                    ]
                 ]
-                [ text "Preview" ]
-            ]
-        , td []
-            [ button
-                [ class "uk-button uk-button-default uk-button-small"
-                , type_ "button"
-                , onClick (SetRoute (Routes.CreateBatch group.id))
-                ]
-                [ text "Create Batch" ]
-            ]
-        , td []
-            [ button
-                [ class "uk-button uk-button-danger uk-button-small"
-                , type_ "button"
-                ]
-                [ text "Delete" ]
-            ]
-        ]

--- a/tests/GroupDecodersTests.elm
+++ b/tests/GroupDecodersTests.elm
@@ -1,0 +1,145 @@
+module GroupDecodersTests exposing (newGroupEncode, noIdDecoder, normalDecoder, simpleEncode)
+
+import Expect exposing (Expectation)
+import Json.Decode as Decode
+import Json.Encode as Encode
+import Models.Group as Group exposing (FormType(..), Group)
+import Requests.Group
+import Test exposing (..)
+
+
+simpleGroup : Group
+simpleGroup =
+    { id = Just 1
+    , name = "IBEW 47 - Class 2"
+    , disclosure = ""
+    , form_type = Ibew
+    , employee_contribution = ""
+    , payment_mode = 12
+    , products = []
+    }
+
+
+normalDecoder : Test
+normalDecoder =
+    test "decodes 'normal' group" <|
+        \_ ->
+            let
+                input =
+                    """
+                    {
+                      "id": "1",
+                      "type": "groups",
+                      "attributes": {
+                        "name": "IBEW 47 - Class 2",
+                        "disclosure": null,
+                        "form_type": "ibew",
+                        "payment_mode": 12,
+                        "created_at": "2018-11-14T12:52:49.778Z"
+                      }
+                    }
+                    """
+
+                decodedOutput =
+                    Decode.decodeString Requests.Group.groupDecoder input
+            in
+            Expect.equal decodedOutput
+                (Ok simpleGroup)
+
+
+noIdDecoder : Test
+noIdDecoder =
+    test "group without id fails to decode" <|
+        \_ ->
+            let
+                input =
+                    """
+                    {
+                      "id": null,
+                      "type": "groups",
+                      "attributes": {
+                        "name": "IBEW 47 - Class 2",
+                        "disclosure": null,
+                        "form_type": "ibew",
+                        "payment_mode": 12,
+                        "created_at": "2018-11-14T12:52:49.778Z"
+                      }
+                    }
+                    """
+
+                decodedOutput =
+                    Decode.decodeString Requests.Group.groupDecoder input
+            in
+            Expect.err decodedOutput
+
+
+simpleEncode : Test
+simpleEncode =
+    test "can encode simple group" <|
+        \_ ->
+            let
+                jsonOutput =
+                    Requests.Group.groupEncoder simpleGroup
+                        |> Encode.encode 2
+
+                expected =
+                    """{
+  "id": 1,
+  "name": "IBEW 47 - Class 2",
+  "disclosure": "",
+  "form_type": "ibew",
+  "employee_contribution": "",
+  "payment_mode": 12,
+  "product_pricing": {
+    "products": []
+  }
+}"""
+            in
+            Expect.equal jsonOutput expected
+
+
+newGroupEncode : Test
+newGroupEncode =
+    test "can encode new group (id = Nothing)" <|
+        \_ ->
+            let
+                newGroup =
+                    { simpleGroup | id = Nothing }
+
+                jsonOutput =
+                    Requests.Group.groupEncoder newGroup
+                        |> Encode.encode 2
+
+                expected =
+                    """{
+  "name": "IBEW 47 - Class 2",
+  "disclosure": "",
+  "form_type": "ibew",
+  "employee_contribution": "",
+  "payment_mode": 12,
+  "product_pricing": {
+    "products": []
+  }
+}"""
+            in
+            Expect.equal jsonOutput expected
+
+
+
+-- roundTrip : Test
+-- roundTrip =
+--     test "object can encode and decode back into itself" <|
+--         \_ ->
+--             simpleGroup
+--                 |> Requests.Group.groupEncoder
+--                 |> Decode.decodeValue Requests.Group.groupDecoder
+--                 |> Expect.equal (Ok simpleGroup)
+--
+-- suite : Test
+-- suite =
+--     describe "Group JSON Encoder / Decoders"
+--         [ describe "Requests.Group.groupDecoder"
+--             [ normalDecoder, noIdDecoder ]
+--         , describe "Round trip"
+--             [ roundTrip ]
+--         ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,0 +1,32 @@
+{
+    "version": "1.0.0",
+    "summary": "Test Suites",
+    "repository": "https://github.com/esbelf/onboard-elm.git",
+    "license": "BSD3",
+    "source-directories": [
+        "../src",
+        "."
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "NoRedInk/elm-decode-pipeline": "3.0.1 <= v < 4.0.0",
+        "eeue56/elm-all-dict": "2.0.1 <= v < 3.0.0",
+        "eeue56/elm-html-test": "5.2.0 <= v < 6.0.0",
+        "elm-community/elm-test": "4.0.0 <= v < 5.0.0",
+        "elm-community/elm-time": "3.0.5 <= v < 4.0.0",
+        "elm-community/json-extra": "2.7.0 <= v < 3.0.0",
+        "elm-community/list-extra": "7.1.0 <= v < 8.0.0",
+        "elm-community/string-extra": "1.5.0 <= v < 2.0.0",
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-lang/dom": "1.1.1 <= v < 2.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0",
+        "elm-lang/navigation": "2.1.0 <= v < 3.0.0",
+        "elm-lang/virtual-dom": "2.0.4 <= v < 3.0.0",
+        "evancz/url-parser": "2.0.1 <= v < 3.0.0",
+        "jweir/elm-iso8601": "4.0.4 <= v < 5.0.0",
+        "krisajenkins/remotedata": "4.5.0 <= v < 5.0.0",
+        "lukewestby/elm-http-builder": "5.2.0 <= v < 6.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -218,6 +218,14 @@ ajv-keywords@^3.1.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
   integrity sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=
 
+ajv@^4.9.1:
+  version "4.11.8"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
+  integrity sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=
+  dependencies:
+    co "^4.6.0"
+    json-stable-stringify "^1.0.1"
+
 ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
@@ -290,7 +298,7 @@ ansi-styles@^2.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
   integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
 
-ansi-styles@^3.2.1:
+ansi-styles@^3.1.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -637,6 +645,14 @@ binary@^0.3.0:
   dependencies:
     buffers "~0.1.1"
     chainsaw "~0.1.0"
+
+binstall@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/binstall/-/binstall-1.2.0.tgz#6b2c0f580b9e3c607f50ef7a22a54ce9fdc8d933"
+  integrity sha1-aywPWAuePGB/UO96IqVM6f3I2TM=
+  dependencies:
+    request "2.79.0"
+    tar "2.2.1"
 
 binwrap@^0.2.0:
   version "0.2.0"
@@ -1178,6 +1194,15 @@ chainsaw@~0.1.0:
   integrity sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=
   dependencies:
     traverse ">=0.3.0 <0.4"
+
+chalk@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  integrity sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
 
 chalk@^0.5.1:
   version "0.5.1"
@@ -2022,6 +2047,30 @@ elm-live@^2.7.5:
     indent-string "^3.0.0"
     q-stream "^0.2.0"
 
+elm-test@0.18.12:
+  version "0.18.12"
+  resolved "https://registry.yarnpkg.com/elm-test/-/elm-test-0.18.12.tgz#8586a056980eb383fd35ad2ef2b74a6ee4c410f7"
+  integrity sha512-5n1uNviCRxXIx5ciaFuzJd3fshcyicbYvTwyGh/L5t05bfBeq/3FZ5a3mLTz+zRZhp18dul2Oz8WoZmcn8PHcg==
+  dependencies:
+    binstall "1.2.0"
+    chalk "2.1.0"
+    chokidar "1.6.0"
+    cross-spawn "4.0.0"
+    find-parent-dir "^0.3.0"
+    firstline "1.2.1"
+    fs-extra "0.30.0"
+    fsevents "1.1.2"
+    glob "^7.1.1"
+    lodash "4.13.1"
+    minimist "^1.2.0"
+    murmur-hash-js "1.0.0"
+    node-elm-compiler "4.3.3"
+    split "^1.0.1"
+    supports-color "4.2.0"
+    xmlbuilder "^8.2.2"
+  optionalDependencies:
+    fsevents "1.1.2"
+
 elm-webpack-loader@^4.5.0:
   version "4.5.0"
   resolved "http://registry.npmjs.org/elm-webpack-loader/-/elm-webpack-loader-4.5.0.tgz#b39988ac7c70db3c0922daf695c97d1d6bdb1e41"
@@ -2423,6 +2472,11 @@ find-elm-dependencies@1.0.2:
     firstline "1.2.0"
     lodash "4.14.2"
 
+find-parent-dir@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
+  integrity sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -2449,6 +2503,11 @@ firstline@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/firstline/-/firstline-1.2.0.tgz#c9f4886e7f7fbf0afc12d71941dce06b192aea05"
   integrity sha1-yfSIbn9/vwr8EtcZQdzgaxkq6gU=
+
+firstline@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/firstline/-/firstline-1.2.1.tgz#b88673c42009f8821fac2926e99720acee924fae"
+  integrity sha1-uIZzxCAJ+IIfrCkm6ZcgrO6ST64=
 
 flush-write-stream@^1.0.0:
   version "1.0.3"
@@ -2496,6 +2555,15 @@ form-data@~1.0.0-rc4:
     combined-stream "^1.0.5"
     mime-types "^2.1.11"
 
+form-data@~2.1.1:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
+  integrity sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.5"
+    mime-types "^2.1.12"
+
 form-data@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
@@ -2537,6 +2605,17 @@ from2@^2.0.3, from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
+fs-extra@0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
+  integrity sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+    klaw "^1.0.0"
+    path-is-absolute "^1.0.0"
+    rimraf "^2.2.8"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -2559,6 +2638,14 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
+fsevents@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.2.tgz#3282b713fb3ad80ede0e9fcf4611b5aa6fc033f4"
+  integrity sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==
+  dependencies:
+    nan "^2.3.0"
+    node-pre-gyp "^0.6.36"
+
 fsevents@^1.0.0, fsevents@^1.2.2:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
@@ -2567,7 +2654,16 @@ fsevents@^1.0.0, fsevents@^1.2.2:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
-fstream@^1.0.2:
+fstream-ignore@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/fstream-ignore/-/fstream-ignore-1.0.5.tgz#9c31dae34767018fe1d249b24dada67d092da105"
+  integrity sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=
+  dependencies:
+    fstream "^1.0.0"
+    inherits "2"
+    minimatch "^3.0.0"
+
+fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
   integrity sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=
@@ -2743,10 +2839,20 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
+graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
+  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
+
 handle-thing@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-1.2.5.tgz#fd7aad726bf1a5fd16dfc29b2f7a6601d27139c4"
   integrity sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=
+
+har-schema@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
+  integrity sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -2762,6 +2868,14 @@ har-validator@~2.0.6:
     commander "^2.9.0"
     is-my-json-valid "^2.12.4"
     pinkie-promise "^2.0.0"
+
+har-validator@~4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
+  integrity sha1-M0gdDxu/9gDdID11gSpqX7oALio=
+  dependencies:
+    ajv "^4.9.1"
+    har-schema "^1.0.5"
 
 har-validator@~5.1.0:
   version "5.1.0"
@@ -2784,6 +2898,11 @@ has-ansi@^2.0.0:
   integrity sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
   dependencies:
     ansi-regex "^2.0.0"
+
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+  integrity sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -2856,7 +2975,7 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hawk@~3.1.3:
+hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
   integrity sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=
@@ -3616,6 +3735,13 @@ json-server@^0.14.0:
     update-notifier "^2.5.0"
     yargs "^10.1.2"
 
+json-stable-stringify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  integrity sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=
+  dependencies:
+    jsonify "~0.0.0"
+
 json-stable-stringify@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz#611c23e814db375527df851193db59dd2af27f45"
@@ -3637,6 +3763,13 @@ json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
+
+jsonfile@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
+  integrity sha1-NzaitCi4e72gzIO1P6PWM6NcKug=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonify@~0.0.0:
   version "0.0.0"
@@ -3691,6 +3824,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
+
+klaw@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
+  integrity sha1-QIhDO0azsbolnXh4XY6W9zugJDk=
+  optionalDependencies:
+    graceful-fs "^4.1.9"
 
 labeled-stream-splicer@^2.0.0:
   version "2.0.1"
@@ -3785,6 +3925,11 @@ lodash@4, lodash@^4.17.10, lodash@^4.17.5:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
   integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
+
+lodash@4.13.1:
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.13.1.tgz#83e4b10913f48496d4d16fec4a560af2ee744b68"
+  integrity sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g=
 
 lodash@4.14.2:
   version "4.14.2"
@@ -4045,7 +4190,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -4201,6 +4346,11 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
+murmur-hash-js@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/murmur-hash-js/-/murmur-hash-js-1.0.0.tgz#5041049269c96633c866386960b2f4289e75e5b0"
+  integrity sha1-UEEEkmnJZjPIZjhpYLL0KJ515bA=
+
 mustache@^2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.2.tgz#a6d4d9c3f91d13359ab889a812954f9230a3d0c5"
@@ -4210,6 +4360,11 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
+
+nan@^2.3.0:
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
+  integrity sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==
 
 nan@^2.9.2:
   version "2.11.0"
@@ -4261,6 +4416,16 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+node-elm-compiler@4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/node-elm-compiler/-/node-elm-compiler-4.3.3.tgz#44e48e8679876bf2f5bd8820dd15734ff3a28caf"
+  integrity sha512-DUqXaoEFcx0xqZnMyYniyEzTKcdBhAC5GAcNsRS4tiG3VR8tidwth73cr5/rc4NzbjXIk+Jje8P4VJI+fWXHuw==
+  dependencies:
+    cross-spawn "4.0.0"
+    find-elm-dependencies "1.0.2"
+    lodash "4.14.2"
+    temp "^0.8.3"
 
 node-elm-compiler@^4.5.0:
   version "4.5.0"
@@ -4321,6 +4486,23 @@ node-pre-gyp@^0.10.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+node-pre-gyp@^0.6.36:
+  version "0.6.39"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"
+  integrity sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==
+  dependencies:
+    detect-libc "^1.0.2"
+    hawk "3.1.3"
+    mkdirp "^0.5.1"
+    nopt "^4.0.1"
+    npmlog "^4.0.2"
+    rc "^1.1.7"
+    request "2.81.0"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^2.2.1"
+    tar-pack "^3.4.0"
 
 node-uuid@~1.4.7:
   version "1.4.8"
@@ -4450,7 +4632,7 @@ on-headers@^1.0.1, on-headers@~1.0.1:
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
   integrity sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=
 
-once@^1.3.0, once@^1.3.1, once@^1.3.2, once@^1.4.0:
+once@^1.3.0, once@^1.3.1, once@^1.3.2, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -4791,6 +4973,11 @@ pem@^1.8.3:
     safe-buffer "^5.1.1"
     which "^1.2.4"
 
+performance-now@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
+  integrity sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -5062,6 +5249,16 @@ qs@~6.2.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.3.tgz#1cfcb25c10a9b2b483053ff39f5dfc9233908cfe"
   integrity sha1-HPyyXBCpsrSDBT/zn138kjOQjP4=
 
+qs@~6.3.0:
+  version "6.3.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
+  integrity sha1-51vV9uJoEioqDgvaYwslUMFmUCw=
+
+qs@~6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+  integrity sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=
+
 querystring-es3@^0.2.0, querystring-es3@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -5135,7 +5332,7 @@ raw-body@~2.1.5:
     iconv-lite "0.4.13"
     unpipe "1.0.0"
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
+rc@^1.0.1, rc@^1.1.6, rc@^1.1.7, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -5169,7 +5366,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.3, readable-stream@^2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.9, readable-stream@^2.3.3, readable-stream@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -5344,6 +5541,60 @@ request@2.74.0:
     tough-cookie "~2.3.0"
     tunnel-agent "~0.4.1"
 
+request@2.79.0:
+  version "2.79.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
+  integrity sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=
+  dependencies:
+    aws-sign2 "~0.6.0"
+    aws4 "^1.2.1"
+    caseless "~0.11.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~2.1.1"
+    har-validator "~2.0.6"
+    hawk "~3.1.3"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    oauth-sign "~0.8.1"
+    qs "~6.3.0"
+    stringstream "~0.0.4"
+    tough-cookie "~2.3.0"
+    tunnel-agent "~0.4.1"
+    uuid "^3.0.0"
+
+request@2.81.0:
+  version "2.81.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
+  integrity sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=
+  dependencies:
+    aws-sign2 "~0.6.0"
+    aws4 "^1.2.1"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~2.1.1"
+    har-validator "~4.2.1"
+    hawk "~3.1.3"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    oauth-sign "~0.8.1"
+    performance-now "^0.2.0"
+    qs "~6.4.0"
+    safe-buffer "^5.0.1"
+    stringstream "~0.0.4"
+    tough-cookie "~2.3.0"
+    tunnel-agent "^0.6.0"
+    uuid "^3.0.0"
+
 request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
@@ -5440,7 +5691,7 @@ right-now@^1.0.0:
   resolved "https://registry.yarnpkg.com/right-now/-/right-now-1.0.0.tgz#6e89609deebd7dcdaf8daecc9aea39cf585a0918"
   integrity sha1-bolgne69fc2vja7Mmuo5z1haCRg=
 
-rimraf@2, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
@@ -5859,6 +6110,13 @@ split2@^0.2.1:
   dependencies:
     through2 "~0.6.1"
 
+split@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
+  integrity sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==
+  dependencies:
+    through "2"
+
 sshpk@^1.7.0:
   version "1.14.2"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.2.tgz#c6fc61648a3d9c4e764fd3fcdf4ea105e492ba98"
@@ -6071,6 +6329,13 @@ supports-color@1.3.1:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-1.3.1.tgz#15758df09d8ff3b4acc307539fabe27095e1042d"
   integrity sha1-FXWN8J2P87SswwdTn6vicJXhBC0=
 
+supports-color@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.0.tgz#ad986dc7eb2315d009b4d77c8169c2231a684037"
+  integrity sha512-Ts0Mu/A1S1aZxEJNG88I4Oc9rcZSBFNac5e27yh4j2mqbhZSSzR1Ah79EYwSn9Zuh7lrlGD2cVGzw1RKGzyLSg==
+  dependencies:
+    has-flag "^2.0.0"
+
 supports-color@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-0.2.0.tgz#d92de2694eb3f67323973d7ae3d8b55b4c22190a"
@@ -6080,6 +6345,13 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
+
+supports-color@^4.0.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+  integrity sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=
+  dependencies:
+    has-flag "^2.0.0"
 
 supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0:
   version "5.5.0"
@@ -6099,6 +6371,20 @@ tapable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.0.0.tgz#cbb639d9002eed9c6b5975eb20598d7936f1f9f2"
   integrity sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg==
+
+tar-pack@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f"
+  integrity sha512-PPRybI9+jM5tjtCbN2cxmmRU7YmqT3Zv/UDy48tAh2XRkLa9bAORtSWLkVc13+GJF+cdTh1yEnHEk3cpTaL5Kg==
+  dependencies:
+    debug "^2.2.0"
+    fstream "^1.0.10"
+    fstream-ignore "^1.0.5"
+    once "^1.3.3"
+    readable-stream "^2.1.4"
+    rimraf "^2.5.1"
+    tar "^2.2.1"
+    uid-number "^0.0.6"
 
 tar@2.2.1, tar@^2.2.1:
   version "2.2.1"
@@ -6161,7 +6447,7 @@ through2@~0.6.1:
     readable-stream ">=1.0.33-1 <1.1.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
-"through@>=2.2.7 <3", through@^2.3.6:
+through@2, "through@>=2.2.7 <3", through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -6330,6 +6616,11 @@ uglifyjs-webpack-plugin@^1.2.4:
     uglify-es "^3.3.4"
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
+
+uid-number@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+  integrity sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=
 
 uikit@^3.0.0-rc.11:
   version "3.0.0-rc.12"
@@ -6524,7 +6815,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.0.1, uuid@^3.3.2:
+uuid@^3.0.0, uuid@^3.0.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
@@ -6802,6 +7093,11 @@ xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
   integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
+
+xmlbuilder@^8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-8.2.2.tgz#69248673410b4ba42e1a6136551d2922335aa773"
+  integrity sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=
 
 xregexp@4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Previously, Group model couldn't distinguish whether or not a group had been created. When attempting to create a group, the request would be sent to update group with an ID of 0, rather than create a new group.

This PR changes the Group model's `id` type from `int` to `Maybe Int`, and the associated logic changes required to handle both creating updating groups.

Also added a couple of simple JSON decoder/encoder tests. They were mainly helpful for my development, but are worth checking in.