### PR TITLE
Group Delete Button Confirmation; Generic Modal view

### DIFF
--- a/src/Pages/Groups.elm
+++ b/src/Pages/Groups.elm
@@ -10,7 +10,9 @@ import Task exposing (Task)
 
 
 type Msg
-    = DeleteGroupRequest Int
+    = ClickedDeleteGroup Int
+    | CancelDeleteGroup
+    | DeleteGroupRequest Int
     | DeleteGroup Int (Result Http.Error String)
     | PreviewGroupRequest Int
     | PreviewGroup Int (Result Http.Error String)
@@ -19,6 +21,7 @@ type Msg
 type alias Model =
     { groups : List Group
     , errorMsg : String
+    , deletingGroup : Maybe Int
     }
 
 
@@ -26,6 +29,7 @@ initialModel : Model
 initialModel =
     { groups = []
     , errorMsg = ""
+    , deletingGroup = Nothing
     }
 
 
@@ -42,6 +46,12 @@ addGroupsToModel groups =
 update : Msg -> Model -> String -> ( Model, Cmd Msg )
 update msg model token =
     case msg of
+        ClickedDeleteGroup id ->
+            ( { model | deletingGroup = Just id }, Cmd.none )
+
+        CancelDeleteGroup ->
+            ( { model | deletingGroup = Nothing }, Cmd.none )
+
         DeleteGroupRequest groupId ->
             let
                 newMsg =
@@ -51,7 +61,12 @@ update msg model token =
             ( model, newMsg )
 
         DeleteGroup id (Ok message) ->
-            ( { model | groups = removeModelFromNullableIdList (Just id) model.groups }, Cmd.none )
+            ( { model
+                | groups = removeModelFromNullableIdList (Just id) model.groups
+                , deletingGroup = Nothing
+              }
+            , Cmd.none
+            )
 
         DeleteGroup id (Err error) ->
             ( { model | errorMsg = toString error }, Cmd.none )

--- a/src/Views/Groups.elm
+++ b/src/Views/Groups.elm
@@ -8,6 +8,7 @@ import Msg exposing (..)
 import Pages.Groups exposing (Model)
 import Route exposing (onClickRoute)
 import Routes exposing (Route)
+import Views.Modal as Modal exposing (ModalButtonStyle(..), modalButton)
 
 
 view : Model -> Html Msg
@@ -35,6 +36,7 @@ view model =
                     (viewGroupList model.groups)
                 ]
             ]
+        , viewDeletingModalIfNeeded model
         ]
 
 
@@ -76,8 +78,49 @@ viewGroup group =
                     [ button
                         [ class "uk-button uk-button-danger uk-button-small"
                         , type_ "button"
-                        , onClick (GroupsMsg (Pages.Groups.DeleteGroupRequest groupId))
+                        , onClick (GroupsMsg (Pages.Groups.ClickedDeleteGroup groupId))
                         ]
                         [ text "Delete" ]
                     ]
                 ]
+
+
+viewDeletingModalIfNeeded : Model -> Html Msg
+viewDeletingModalIfNeeded model =
+    case model.deletingGroup of
+        Just groupId ->
+            viewDeletingModal model groupId
+
+        Nothing ->
+            text ""
+
+
+viewDeletingModal : Model -> Int -> Html Msg
+viewDeletingModal model groupId =
+    let
+        maybeGroup =
+            model.groups
+                |> List.filter (\g -> g.id == model.deletingGroup)
+                |> List.head
+    in
+    case maybeGroup of
+        Just group ->
+            let
+                content =
+                    p []
+                        [ text
+                            ("Remove group '"
+                                ++ group.name
+                                ++ "' ? This cannot be undone. Are you sure?"
+                            )
+                        ]
+
+                buttons =
+                    [ modalButton "Cancel" (GroupsMsg Pages.Groups.CancelDeleteGroup) ModalDefault
+                    , modalButton "Delete" (GroupsMsg <| Pages.Groups.DeleteGroupRequest groupId) ModalDanger
+                    ]
+            in
+            Modal.displayModal "Delete Group" content buttons
+
+        Nothing ->
+            text ""

--- a/src/Views/Modal.elm
+++ b/src/Views/Modal.elm
@@ -1,0 +1,71 @@
+module Views.Modal exposing (ModalButtonSpec, ModalButtonStyle(..), displayModal, modalButton)
+
+import Html exposing (Html, button, div, h2, p, text)
+import Html.Attributes exposing (attribute, class, style, type_)
+import Html.Events exposing (onClick)
+
+
+type ModalButtonStyle
+    = ModalDefault
+    | ModalPrimary
+    | ModalSecondary
+    | ModalDanger
+
+
+type alias ModalButtonSpec msg =
+    { label : String
+    , action : msg
+    , style : ModalButtonStyle
+    }
+
+
+modalButton : String -> msg -> ModalButtonStyle -> ModalButtonSpec msg
+modalButton =
+    ModalButtonSpec
+
+
+displayModal : String -> Html msg -> List (ModalButtonSpec msg) -> Html msg
+displayModal title content buttonList =
+    div
+        [ class "uk-modal uk-open"
+        , attribute "uk-modal" ""
+        , style [ ( "display", "block" ) ]
+        ]
+        [ div [ class "uk-modal-dialog uk-modal-body" ]
+            [ h2 [ class "uk-modal-title" ]
+                [ text title ]
+            , content
+            , p [ class "uk-text-right" ]
+                (List.map displayButton buttonList)
+            ]
+        ]
+
+
+
+-- PRIVATE
+
+
+displayButton : ModalButtonSpec msg -> Html msg
+displayButton buttonSpec =
+    button
+        [ buttonClass buttonSpec.style
+        , type_ "button"
+        , onClick buttonSpec.action
+        ]
+        [ text buttonSpec.label ]
+
+
+buttonClass : ModalButtonStyle -> Html.Attribute msg
+buttonClass style =
+    case style of
+        ModalDefault ->
+            class "uk-button uk-button-default uk-modal-close"
+
+        ModalPrimary ->
+            class "uk-button uk-button-primary"
+
+        ModalSecondary ->
+            class "uk-button uk-button-secondary"
+
+        ModalDanger ->
+            class "uk-button uk-button-danger"

--- a/src/Views/Product.elm
+++ b/src/Views/Product.elm
@@ -11,6 +11,7 @@ import Json.Encode
 import List.Extra
 import Models.Product exposing (..)
 import Requests.Product exposing (encode)
+import Views.Modal as Modal exposing (ModalButtonStyle(..), modalButton)
 
 
 view : Components.Product.Model -> Html Components.Product.Msg
@@ -513,16 +514,9 @@ renderModal model =
 
                         BenefitTier ->
                             ""
-            in
-            div
-                [ class "uk-modal uk-open"
-                , attribute "uk-modal" ""
-                , style [ ( "display", "block" ) ]
-                ]
-                [ div [ class "uk-modal-dialog uk-modal-body" ]
-                    [ h2 [ class "uk-modal-title" ]
-                        [ text "Remove Tier" ]
-                    , p []
+
+                content =
+                    p []
                         [ text
                             ("You are removing the "
                                 ++ tierTypeDisplay
@@ -533,19 +527,10 @@ renderModal model =
                                 ++ " and deleting all associated pricing.  This cannot be undone.  Are you sure you want to continue?"
                             )
                         ]
-                    , p [ class "uk-text-right" ]
-                        [ button
-                            [ class "uk-button uk-button-default uk-modal-close"
-                            , type_ "button"
-                            , onClick Components.Product.CancelRemoveTier
-                            ]
-                            [ text "Cancel" ]
-                        , button
-                            [ class "uk-button uk-button-primary"
-                            , type_ "button"
-                            , onClick Components.Product.RemoveTier
-                            ]
-                            [ text "Delete" ]
-                        ]
+
+                buttons =
+                    [ modalButton "Cancel" Components.Product.CancelRemoveTier ModalDefault
+                    , modalButton "Delete" Components.Product.RemoveTier ModalPrimary
                     ]
-                ]
+            in
+            Modal.displayModal "Remove Tier" content buttons


### PR DESCRIPTION
- Delete buttons on Groups page have confirmation modal
- Create Generic Modal view (and convert Product's confirmation dialog to use it as well)